### PR TITLE
Stub pg-hstore to unblock browser build

### DIFF
--- a/src/shims/pg-hstore.ts
+++ b/src/shims/pg-hstore.ts
@@ -1,0 +1,10 @@
+export default function pgHstoreStub() {
+  return {
+    parse() {
+      throw new Error('pg-hstore is not available in this environment');
+    },
+    stringify() {
+      throw new Error('pg-hstore is not available in this environment');
+    }
+  } as any;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,17 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: { port: 5173 },
+  resolve: {
+    alias: {
+      'pg-hstore': '/src/shims/pg-hstore.ts',
+    },
+  },
+  optimizeDeps: {
+    exclude: ['pg-hstore'],
+  },
+  build: {
+    rollupOptions: {
+      external: ['pg-hstore'],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Provide minimal pg-hstore stub and alias so esbuild doesn't try to resolve missing package
- Configure Vite to externalize pg-hstore during pre-bundling and rollup build

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build` *(fails: Rollup failed to resolve import "sequelize")*

------
https://chatgpt.com/codex/tasks/task_e_68c700eeecc4832cb59822d96f61585b