### PR TITLE
Add React Router for page navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "sqlite3": "^5.1.7",
     "zustand": "^4.5.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Routes, Route, useNavigate, useLocation, Navigate } from 'react-router-dom'
 import {
   AppBar,
   Box,
@@ -19,7 +20,9 @@ import LedgerTable from './features/ledger/LedgerTable'
 import BalancesGrid from './features/balances/BalancesGrid'
 
 export default function App() {
-  const [tab, setTab] = useState(0)
+  const location = useLocation()
+  const navigate = useNavigate()
+  const tab = location.pathname === '/ledger' ? 1 : location.pathname === '/balances' ? 2 : 0
   const [bootMsg, setBootMsg] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -60,15 +63,22 @@ export default function App() {
           </Box>
         ) : (
           <>
-            <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+            <Tabs
+              value={tab}
+              onChange={(_, v) => navigate(v === 0 ? '/' : v === 1 ? '/ledger' : '/balances')}
+              sx={{ mb: 2 }}
+            >
               <Tab label="Add Transaction" />
               <Tab label="Ledger" />
               <Tab label="Balances" />
             </Tabs>
 
-            {tab === 0 && <AddTransaction />}
-            {tab === 1 && <LedgerTable />}
-            {tab === 2 && <BalancesGrid />}
+            <Routes>
+              <Route path="/" element={<AddTransaction />} />
+              <Route path="/ledger" element={<LedgerTable />} />
+              <Route path="/balances" element={<BalancesGrid />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
           </>
         )}
       </Container>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { CssBaseline, ThemeProvider } from '@mui/material'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import theme from './theme'
 
@@ -8,7 +9,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ThemeProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- integrate react-router-dom for routing between pages
- wrap root component with BrowserRouter
- render Add Transaction, Ledger, and Balances via React Router instead of local tab state

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c707ab9a2c832c9441431003172d43